### PR TITLE
Update the link of contributors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 sphinx
 sphinx-cjkspace
-sphinxcontrib-ghcontributors
 sphinx-copybutton
 sphinx_gmt
 sphinx_rtd_theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -36,7 +36,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx_cjkspace.cjkspace",
-    "sphinxcontrib.ghcontributors",
     "sphinx_copybutton",
     "sphinx_gmt.gmtplot",
 ]

--- a/source/contributors.rst
+++ b/source/contributors.rst
@@ -1,7 +1,0 @@
-贡献者列表
-==========
-
-感谢如下贡献者对《GMT中文手册》的贡献与维护。欢迎更多GMT用户参与到手册的维护中。
-
-..  ghcontributors:: gmt-china/GMT_docs
-    :limit: 100

--- a/source/index.rst
+++ b/source/index.rst
@@ -71,4 +71,4 @@ GMT 是地球科学最广泛使用的制图软件之一。
 
    appendix/index
    contributing
-   contributors
+   贡献者列表 <https://github.com/gmt-china/GMT_docs/graphs/contributors>


### PR DESCRIPTION
原来是使用 sphinx 插件生成贡献者列表，感觉没有必要，直接链接到 github 的贡献者页面更简单。