### PR TITLE
Remove gitalk comments

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -24,27 +24,6 @@
     {% endif %}
 {% endblock %}
 
-{% block comments %}
-{{ super() }}
-<!-- gitalk 脚本-->
-<div id="gitalk-container"></div>
-<link rel="stylesheet" href="https://unpkg.com/gitalk/dist/gitalk.css">
-<script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
-<script src="https://cdn.bootcss.com/blueimp-md5/2.12.0/js/md5.min.js"></script>
-<script type="text/javascript">
-  var gitalk = new Gitalk({
-    clientID: 'b2dfca9a4bfad764aa2b',
-    clientSecret: '4ae5ddcd25c6b6d6bc07ac39201ea417054a530a',
-    owner: 'gmt-china',
-    repo: 'gitalk',
-    admin: ['zhaozhiyuan1989','cehui07226','NothingIsBig','seisman','SeisPider','wangliang1989','sqdeng'],
-    id: md5(location.pathname),
-    body: location.href,
-  });
-gitalk.render('gitalk-container');
-</script>
-{% endblock %}
-
 {%- block sidebartitle %}
 
 {%- if logo and theme_logo_only %}


### PR DESCRIPTION
Very few users leave comments on the website, while gitalk makes the pages too long to read.

This PR removes the gitalk comment system.