### PR TITLE
Update -n option

### DIFF
--- a/source/option/n.rst
+++ b/source/option/n.rst
@@ -24,9 +24,6 @@
   使用 **+c** 则将超过 *zmin* 和 *zmax* 的部分裁剪掉，以保证插值后的网格数据的范围
   不超过输入网格数据的范围
 - **+t**\ *threshold* 用于控制值为 NaN 的网格点在插值时的影响范围 [默认值为 0.5]。
-  A *threshold* of 1.0 requires all (4 or 16) nodes involved in
-  interpolation to be non-NaN. 0.5 will interpolate about half way
-  from a non-NaN value; 0.1 will go about 90% of the way, etc.
   *threshold* 设置为 1.0 时，表示插值中的所有节点（4 或 16 个）都要为非 NaN；
   0.5 表示距非 NaN 值的大约一半处进行插值；0.1 表示距非 NaN 值的大约 90% 处进行插值；
   依此类推。

--- a/source/option/n.rst
+++ b/source/option/n.rst
@@ -23,7 +23,10 @@
 - **+c**\ ：假设原网格的Z值范围为 *zmin* 到 *zmax*\ ，插值后的Z值范围可能会超过这一范围，
   使用 **+c** 则将超过 *zmin* 和 *zmax* 的部分裁剪掉，以保证插值后的网格数据的范围
   不超过输入网格数据的范围
-- **+t**\ *threshold* 用于控制值为NaN的网格点在插值时的影响范围 [默认值为0.5]
+- **+t**\ *threshold* 用于控制值为 NaN 的网格点在插值时的影响范围 [默认值为 0.5]。
   A *threshold* of 1.0 requires all (4 or 16) nodes involved in
   interpolation to be non-NaN. 0.5 will interpolate about half way
   from a non-NaN value; 0.1 will go about 90% of the way, etc.
+  *threshold* 设置为 1.0 时，表示插值中的所有节点（4 或 16 个）都要为非 NaN；
+  0.5 表示距非 NaN 值的大约一半处进行插值；0.1 表示距非 NaN 值的大约 90% 处进行插值；
+  依此类推。


### PR DESCRIPTION
**Preview:** https://gmt-china.github.io/sitepreview/gmt-china/GMT_docs/n-option/option/n/

See https://docs.generic-mapping-tools.org/6.1/cookbook/options.html#grid-interpolation-parameters-the-n-option:
> A threshold of 1.0 requires all (4 or 16) nodes involved in the interpolation to be non-NaN. 0.5 will interpolate about half way from a non-NaN value; 0.1 will go about 90% of the way, etc.