### PR TITLE
Update resources

### DIFF
--- a/source/intro/resources.rst
+++ b/source/intro/resources.rst
@@ -22,12 +22,10 @@
 
 #. `GMT官方示例 <https://docs.generic-mapping-tools.org/6.2/gallery.html>`__
 #. `GMT官方动画示例 <https://docs.generic-mapping-tools.org/6.2/animations.html>`__
-#. `GMT中文社区示例 <https://gmt-china.org/gallery/>`__
-#. `GMT中文社区博客 <https://gmt-china.org/blog/>`__
+#. :doc:`GMT中文社区示例 </examples/index>`
 #. `GMT YouTube Channel <https://www.youtube.com/channel/UCo1drOh0OZPcB7S8TmIyf8Q>`__
 
 **论坛/讨论组**
 
 #. 地学GMT中文社区QQ群：1群（218905582）；2群（791856541）[**请勿重复加群!**]
 #. `GMT官方论坛 <https://forum.generic-mapping-tools.org/>`_
-#. `GMT Gitter 聊天室 <https://gitter.im/GenericMappingTools>`_


### PR DESCRIPTION
1. Delete links to the gmt-china main site
2. Add the link to the docs.gmt-china.org gallery
3. Remove the link to the Gitter because it's not used
