### PR TITLE
Add the sphinx.ext.duration to show the slowest pages

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -29,7 +29,7 @@ rst_prolog = """
 """
 
 # -- General configuration ------------------------------------------------
-needs_sphinx = "1.8"
+needs_sphinx = "2.4"
 source_suffix = ".rst"
 source_encoding = "utf-8-sig"
 nitpicky = True
@@ -42,6 +42,7 @@ pygments_style = "sphinx"
 show_authors = True
 
 extensions = [
+    "sphinx.ext.duration",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx_cjkspace.cjkspace",


### PR DESCRIPTION
The extension will show the following lines at the end of the output:
```
====================== slowest reading durations =======================
24.551 tutorial/layers/index
19.963 tutorial/earth-relief
13.095 contour-annot
12.630 option/B
11.932 examples/ex029/index
```
