### PR TITLE
Use old PDF if the new one is not built

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,8 +83,13 @@ jobs:
       - name: Push the documentation to gh-pages
         run: |
           cd deploy
+          # generate the .nojekyll file in the root directory
           touch .nojekyll
-          # Update the directory
+          # Use the old PDF documentation if the new PDF documentation is not built
+          if [ ! -f ../build/dirhtml/GMT_docs.pdf ]; then
+            cp ${GMT_DOC_VERSION}/GMT_docs.pdf ../build/dirhtml/
+          fi
+          # Replace the old documentation with tht new one.
           rm -rvf ${GMT_DOC_VERSION}
           cp -rvf ../build/dirhtml/ ${GMT_DOC_VERSION}/
           # let "latest" link to the latest version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 name: Deploy
 
 on:
-  #pull_request: # enable pull_request for testing
+  pull_request: # enable pull_request for testing
   push:
     branches:
       - master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 name: Deploy
 
 on:
-  pull_request: # enable pull_request for testing
+  #pull_request: # enable pull_request for testing
   push:
     branches:
       - master


### PR DESCRIPTION
Sometimes, building PDF may fail due to broken LaTeX packages (#573), and we
have to disable the PDF build to make the CI job pass. However, when PDF building
is disabled, the PDF documentation no longer exists and users won't be able to
download the PDF documentation.

This PR fixes the problem. When the new PDF documentation is not built,
we will use the old PDF documentation.
