### PR TITLE
Remove sphinx-watch from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ export GMT_END_SHOW=off
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile build build_html build_pdf optimize_pdf serve watch
+.PHONY: help Makefile build build_html build_pdf optimize_pdf serve
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
@@ -40,8 +40,3 @@ optimize_pdf: latexpdf
 
 serve: $(HTML)
 	cd $(BUILDDIR)/$(HTML) && python -m http.server
-
-# Watch a Sphinx directory and rebuild the documentation when a change is detected.
-# See https://github.com/GaretJax/sphinx-autobuild for details
-watch:
-	sphinx-autobuild --open-browser --delay 1 -b ${HTML} ${SPHINXOPTS} $(SOURCEDIR) $(BUILDDIR)/${HTML}


### PR DESCRIPTION
sphinx-watch is used to preview the documentation locally, but it's less useful
after we can preview the changes in PRs.
