### PR TITLE
Show date of the link check report

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -37,11 +37,13 @@ jobs:
           --verbose
           "repository/*.md"
           "documentation/latest/**/*.html"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
     - name: Create Issue From File
-      uses: peter-evans/create-issue-from-file@v3
+      uses: peter-evans/create-issue-from-file@v3.0.0
       with:
-        title: Link Checker Report
+        title: Link Checker Report on ${{ steps.date.outputs.date }}
         content-filepath: ./lychee/out.md

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,7 @@ name: Check Links
 
 on:
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
-  pull_request:
+  #pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,7 @@ name: Check Links
 
 on:
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
-  #pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'


### PR DESCRIPTION
Changes in this PR:

- `GITHUB_TOKEN` is no longer a required parameter for `lycheeverse/lychee-action`
- Pin action peter-evans/create-issue-from-file to v3.0.0
- Show the date on the issue title