### PR TITLE
Generate the CNAME file in the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,8 @@ jobs:
           cd deploy
           # generate the .nojekyll file in the root directory
           touch .nojekyll
+          # generate CNAME in the root directory
+          cat docs.gmt-china.org > CNAME
           # Use the old PDF documentation if the new PDF documentation is not built
           if [ ! -f ../build/dirhtml/GMT_docs.pdf ]; then
             cp ${GMT_DOC_VERSION}/GMT_docs.pdf ../build/dirhtml/

--- a/source/CNAME
+++ b/source/CNAME
@@ -1,1 +1,0 @@
-docs.gmt-china.org


### PR DESCRIPTION
在 gh-pages 分支里，需要在根目录下有 `CNAME` 文件才能正常解析域名。

`source/CNAME` 文件会被放在 `6.2/CNAME` 下，所以本质上是没有起任何作用的。

gh-pages 分支根目录的 CNAME 文件是之前我手动创建的。

这个PR做了两件事情：

- 在 deploy 的时候总是在根目录生成 CNAME 文件
- 删除 source 目录下的 CNAME 文件