### PR TITLE
Fix bug in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
           # generate the .nojekyll file in the root directory
           touch .nojekyll
           # generate CNAME in the root directory
-          cat docs.gmt-china.org > CNAME
+          echo docs.gmt-china.org > CNAME
           # Use the old PDF documentation if the new PDF documentation is not built
           if [ ! -f ../build/dirhtml/GMT_docs.pdf ]; then
             cp ${GMT_DOC_VERSION}/GMT_docs.pdf ../build/dirhtml/


### PR DESCRIPTION
See https://github.com/gmt-china/GMT_docs/runs/3075056599?check_suite_focus=true:

> cat: docs.gmt-china.org: No such file or directory
> Error: Process completed with exit code 1.

`cat` was changed to `echo`.