### PR TITLE
Remove jieba from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,3 @@ sphinx-cjkspace
 sphinx-copybutton
 sphinx_gmt
 sphinx_rtd_theme
-# jieba is necessary for Chinese search
-jieba


### PR DESCRIPTION
jieba is only needed if we use the sphinx built-in search engine.

We now use Bing instead, so it's safe to remove it, but we may add it back
when addressing #640.

