### PR TITLE
Update the install index page to show deeper levels

### DIFF
--- a/source/install/index.rst
+++ b/source/install/index.rst
@@ -7,11 +7,15 @@
 不同操作系统下安装 GMT 二进制包：
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    linux
-   windows
    macOS
+
+.. toctree::
+   :maxdepth: 1
+
+   windows
 
 同时适用于 Linux、macOS 以及 Windows 的 GMT 二进制包安装（即跨平台安装）：
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3974108/126091933-705d0bd9-515b-4e95-a1ea-ec61a73f20da.png)

Do you think showing the 2nd level headings is better?