### PR TITLE
Rename cross-platform.rst to conda.rst

### DIFF
--- a/source/install/conda.rst
+++ b/source/install/conda.rst
@@ -1,10 +1,5 @@
-跨平台安装 GMT
-==============
-
-跨平台安装是指同时适用于 Linux、macOS 以及 Windows 的安装方式。
-
-通过 conda 安装
----------------
+通过 conda 安装 GMT
+===================
 
 `conda <https://conda.io/>`_ 是由 `Anaconda <https://www.anaconda.com/>`__
 提供的一个跨平台软件包管理器。
@@ -15,7 +10,7 @@ Anaconda 用户可以直接通过以下命令安装、升级以及卸载 GMT。
 可以参考 `Anaconda 简易教程 <https://seismo-learn.org/software/anaconda/>`__ 安装 Anaconda。
 
 安装 GMT
-^^^^^^^^^
+--------
 
 1.  安装 GMT
 
@@ -33,14 +28,14 @@ Anaconda 用户可以直接通过以下命令安装、升级以及卸载 GMT。
         6.2.0
 
 升级 GMT
-^^^^^^^^^
+--------
 
 GMT 新版本发布后，执行如下命令升级 GMT::
 
     $ conda update gmt
 
 卸载 GMT
-^^^^^^^^^
+--------
 
 可以执行如下命令卸载 GMT::
 

--- a/source/install/index.rst
+++ b/source/install/index.rst
@@ -6,7 +6,6 @@
 
 不同操作系统下安装 GMT 二进制包：
 
-
 .. toctree::
    :maxdepth: 1
 
@@ -17,12 +16,12 @@
    ubuntu-debian
    archlinux
 
-同时适用于 Linux、macOS 以及 Windows 的 GMT 二进制包安装（即跨平台安装）：
+跨平台软件包管理器 **conda** 为 Linux、macOS 和 Windows 提供了 GMT 二进制包：
 
 .. toctree::
    :maxdepth: 1
 
-   cross-platform
+   conda
 
 某些 Linux 发行版未提供最新版本的 GMT 二进制包。可以选择编译源码安装：
 


### PR DESCRIPTION
conda 是目前已知的唯一一个跨平台安装方式。因而可以把 conda 安装作为单独的一节。