### PR TITLE
Remove ArchLinux install instructions

### DIFF
--- a/source/install/archlinux.rst
+++ b/source/install/archlinux.rst
@@ -1,4 +1,0 @@
-ArchLinux
-=========
-
-ArchLinux 用户请参考 https://github.com/GenericMappingTools/gmt/wiki/Install-latest-GMT-on-ArchLinux

--- a/source/install/index.rst
+++ b/source/install/index.rst
@@ -14,7 +14,6 @@
    fedora
    centos
    ubuntu-debian
-   archlinux
 
 跨平台软件包管理器 **conda** 为 Linux、macOS 和 Windows 提供了 GMT 二进制包：
 


### PR DESCRIPTION
Because we don't use ArchLinux and it's not that popupar in seismology community.
