### PR TITLE
Add the sphinx-cjkspace extension

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
 sphinx-copybutton
+sphinx-cjkspace
 sphinx_gmt
 sphinx_rtd_theme

--- a/source/conf.py
+++ b/source/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx_copybutton",
+    "sphinx_cjkspace.cjkspace",
     "sphinx_gmt.gmtplot",
 ]
 mathjax_path = "https://cdn.bootcss.com/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML"


### PR DESCRIPTION
sphinx-cjkspace 在 https://github.com/gmt-china/GMT_docs/pull/666 中被移除。但移除后会导致段落中出现额外空格，比如首页里：

![image](https://user-images.githubusercontent.com/3974108/127211902-ffa53cb8-48c1-45e3-a292-65604174a0a7.png)

这是因为 Sphinx 会自动在换行处加上空格。比如：
```
First line
second line
```
在网页中会显示为 `First line second line`。但这样的处理对于中文来说是错误的。

因而 sphinx-cjkspace 依然是有必要的。