### PR TITLE
Fix an invalid url for Fedora repo

### DIFF
--- a/source/install/build-source-unix.rst
+++ b/source/install/build-source-unix.rst
@@ -36,7 +36,7 @@ Fedora::
     $ sudo dnf install gcc cmake make glibc netcdf-devel libcurl-devel
     # 安装可选软件包
     $ sudo dnf install ghostscript gdal gdal-devel lapack-devel openblas-devel glib2-devel pcre-devel fftw-devel
-    $ sudo dnf install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-`rpm -E %fedora`.noarch.rpm
+    $ sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-`rpm -E %fedora`.noarch.rpm
     $ sudo dnf install GraphicsMagick ffmpeg
 
 CentOS::


### PR DESCRIPTION
The Fedora repo url is not valid. It is https://download1.rpmfusion.org/free/fedora/ instead of https://download1.rpmfusion.org/el/

```
$ sudo dnf install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-`rpm -E %fedora`.noarch.rpm
Last metadata expiration check: 1:06:31 ago on Thu 18 Nov 2021 03:32:49 PM CST.
[MIRROR] rpmfusion-free-release-35.noarch.rpm: Status code: 404 for https://download1.rpmfusion.org/free/el/rpmfusion-free-release-35.noarch.rpm (IP: 193.28.235.60)
[MIRROR] rpmfusion-free-release-35.noarch.rpm: Status code: 404 for https://download1.rpmfusion.org/free/el/rpmfusion-free-release-35.noarch.rpm (IP: 193.28.235.60)
[MIRROR] rpmfusion-free-release-35.noarch.rpm: Status code: 404 for https://download1.rpmfusion.org/free/el/rpmfusion-free-release-35.noarch.rpm (IP: 193.28.235.60)
[MIRROR] rpmfusion-free-release-35.noarch.rpm: Status code: 404 for https://download1.rpmfusion.org/free/el/rpmfusion-free-release-35.noarch.rpm (IP: 193.28.235.60)
[FAILED] rpmfusion-free-release-35.noarch.rpm: Status code: 404 for https://download1.rpmfusion.org/free/el/rpmfusion-free-release-35.noarch.rpm (IP: 193.28.235.60)
Status code: 404 for https://download1.rpmfusion.org/free/el/rpmfusion-free-release-35.noarch.rpm (IP: 193.28.235.60)
```

See https://rpmfusion.org/Configuration.