### PR TITLE
Speed up the documentation deployment by deploying HTML and PDF separately

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          force_orphan: true
           publish_dir: deploy
           publish_branch: gh-pages-testing
 
@@ -117,5 +118,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          force_orphan: true
           publish_dir: deploy
           publish_branch: gh-pages-testing

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 name: Deploy
 
 on:
-  pull_request: # enable pull_request for testing
+  # pull_request: # enable pull_request for testing
   push:
     branches:
       - master
@@ -92,7 +92,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force_orphan: true
           publish_dir: deploy
-          publish_branch: gh-pages-testing
 
       - name: Install TinyTeX
         uses: r-lib/actions/setup-tinytex@v2
@@ -120,4 +119,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force_orphan: true
           publish_dir: deploy
-          publish_branch: gh-pages-testing

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Checkout the gh-pages branch
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+          path: deploy
+          fetch-depth: 0
+
       # Install Mambaforge with conda-forge dependencies
       - name: Setup Mambaforge
         uses: conda-incubator/setup-miniconda@v2.1.1
@@ -59,6 +66,9 @@ jobs:
           touch ~/.gmt/server/gmt_data_server.txt ~/.gmt/server/gmt_hash_server.txt
           ls -lhR ~/.gmt
 
+      - name: Build HTML
+        run: make build_html
+
       - name: Install TinyTeX
         uses: r-lib/actions/setup-tinytex@v2
 
@@ -72,18 +82,8 @@ jobs:
           # install packages for GMT LaTeX integration
           tlmgr install collection-fontsrecommended
 
-      - name: Build HTML
-        run: make build_html
-
       - name: Build PDF
         run: make build_pdf
-
-      - name: Checkout the gh-pages branch
-        uses: actions/checkout@v3
-        with:
-          ref: gh-pages
-          path: deploy
-          fetch-depth: 0
 
       # - name: Push the documentation to gh-pages
       #   run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,13 +109,15 @@ jobs:
       - name: Build PDF
         run: make build_pdf
 
-      # - name: Push the documentation to gh-pages
-      #   run: |
-      #     # commit all changes
-      #     git add -A .
-      #     git status
-      #     git config user.email "github-actions[bot]@users.noreply.github.com"
-      #     git config user.name "github-actions[bot]"
-      #     message="Deploy ${GITHUB_SHA::8}"
-      #     git commit --amend --reset-author -m "$message"
-      #     git push -fq origin gh-pages 2>&1 >/dev/null
+      - name: Prepare the documentation for deployment
+        run: |
+          cd deploy
+          cp build/dirhtml/GMT_Docs.pdf ${GMT_DOC_VERSION}/
+          cd ..
+
+      - name: Deploy the PDF documentation to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: deploy
+          publish_branch: gh-pages-testing

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,29 @@ jobs:
       - name: Build HTML
         run: make build_html
 
+      - name: Prepare the documentation for deployment
+        run: |
+          cd deploy
+          # generate the .nojekyll file in the root directory
+          touch .nojekyll
+          # generate CNAME in the root directory
+          echo docs.gmt-china.org > CNAME
+          # Use the old PDF documentation because the new PDF documentation is not built
+          cp ${GMT_DOC_VERSION}/GMT_docs.pdf ../build/dirhtml/
+          # Replace the old documentation with tht new one.
+          rm -rvf ${GMT_DOC_VERSION}
+          cp -rvf ../build/dirhtml/ ${GMT_DOC_VERSION}/
+          # let "latest" link to the latest version
+          rm -f latest
+          ln -sf ${GMT_DOC_VERSION} latest
+          cd ..
+
+      - name: Deploy the HTML documentation to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: deploy
+
       - name: Install TinyTeX
         uses: r-lib/actions/setup-tinytex@v2
 
@@ -87,21 +110,6 @@ jobs:
 
       # - name: Push the documentation to gh-pages
       #   run: |
-      #     cd deploy
-      #     # generate the .nojekyll file in the root directory
-      #     touch .nojekyll
-      #     # generate CNAME in the root directory
-      #     echo docs.gmt-china.org > CNAME
-      #     # Use the old PDF documentation if the new PDF documentation is not built
-      #     if [ ! -f ../build/dirhtml/GMT_docs.pdf ]; then
-      #       cp ${GMT_DOC_VERSION}/GMT_docs.pdf ../build/dirhtml/
-      #     fi
-      #     # Replace the old documentation with tht new one.
-      #     rm -rvf ${GMT_DOC_VERSION}
-      #     cp -rvf ../build/dirhtml/ ${GMT_DOC_VERSION}/
-      #     # let "latest" link to the latest version
-      #     rm -f latest
-      #     ln -sf ${GMT_DOC_VERSION} latest
       #     # commit all changes
       #     git add -A .
       #     git status

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,9 +111,7 @@ jobs:
 
       - name: Prepare the documentation for deployment
         run: |
-          cd deploy
-          cp build/dirhtml/GMT_Docs.pdf ${GMT_DOC_VERSION}/
-          cd ..
+          cp build/dirhtml/GMT_docs.pdf deploy/${GMT_DOC_VERSION}/
 
       - name: Deploy the PDF documentation to gh-pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: deploy
+          publish_branch: gh-pages-testing
 
       - name: Install TinyTeX
         uses: r-lib/actions/setup-tinytex@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 name: Deploy
 
 on:
-  #pull_request: # enable pull_request for testing
+  pull_request: # enable pull_request for testing
   push:
     branches:
       - master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,28 +85,28 @@ jobs:
           path: deploy
           fetch-depth: 0
 
-      - name: Push the documentation to gh-pages
-        run: |
-          cd deploy
-          # generate the .nojekyll file in the root directory
-          touch .nojekyll
-          # generate CNAME in the root directory
-          echo docs.gmt-china.org > CNAME
-          # Use the old PDF documentation if the new PDF documentation is not built
-          if [ ! -f ../build/dirhtml/GMT_docs.pdf ]; then
-            cp ${GMT_DOC_VERSION}/GMT_docs.pdf ../build/dirhtml/
-          fi
-          # Replace the old documentation with tht new one.
-          rm -rvf ${GMT_DOC_VERSION}
-          cp -rvf ../build/dirhtml/ ${GMT_DOC_VERSION}/
-          # let "latest" link to the latest version
-          rm -f latest
-          ln -sf ${GMT_DOC_VERSION} latest
-          # commit all changes
-          git add -A .
-          git status
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          message="Deploy ${GITHUB_SHA::8}"
-          git commit --amend --reset-author -m "$message"
-          git push -fq origin gh-pages 2>&1 >/dev/null
+      # - name: Push the documentation to gh-pages
+      #   run: |
+      #     cd deploy
+      #     # generate the .nojekyll file in the root directory
+      #     touch .nojekyll
+      #     # generate CNAME in the root directory
+      #     echo docs.gmt-china.org > CNAME
+      #     # Use the old PDF documentation if the new PDF documentation is not built
+      #     if [ ! -f ../build/dirhtml/GMT_docs.pdf ]; then
+      #       cp ${GMT_DOC_VERSION}/GMT_docs.pdf ../build/dirhtml/
+      #     fi
+      #     # Replace the old documentation with tht new one.
+      #     rm -rvf ${GMT_DOC_VERSION}
+      #     cp -rvf ../build/dirhtml/ ${GMT_DOC_VERSION}/
+      #     # let "latest" link to the latest version
+      #     rm -f latest
+      #     ln -sf ${GMT_DOC_VERSION} latest
+      #     # commit all changes
+      #     git add -A .
+      #     git status
+      #     git config user.email "github-actions[bot]@users.noreply.github.com"
+      #     git config user.name "github-actions[bot]"
+      #     message="Deploy ${GITHUB_SHA::8}"
+      #     git commit --amend --reset-author -m "$message"
+      #     git push -fq origin gh-pages 2>&1 >/dev/null


### PR DESCRIPTION
When we merge changes into the master branch, the `deploy.yml` workflow builds the HTML and PDF documentation, and then deploy them to the gh-pages branch. The workflow takes 4 minutes for building the HTML and another 6 minutes for building the PDF.

So, if we deploy the HTML files immediately after finishing the HTML documentation, we only need to wait ~6 minutes.

This PR tries to deploy HTML files and PDF files separately.

