### PR TITLE
Change the column number of module list to 4

### DIFF
--- a/source/module/index.rst
+++ b/source/module/index.rst
@@ -4,7 +4,7 @@
 **GMT 主程序与脚本**
 
 .. hlist::
-    :columns: 6
+    :columns: 5
 
     - :doc:`gmt`
     - :doc:`gmt-config`
@@ -13,7 +13,7 @@
 **GMT 模块（已翻译整理）**
 
 .. hlist::
-    :columns: 6
+    :columns: 5
 
     - :doc:`basemap`
     - :doc:`begin`
@@ -142,7 +142,7 @@
 **GMT 模块（尚未翻译整理，欢迎贡献）**
 
 .. hlist::
-    :columns: 6
+    :columns: 5
 
     - :doc:`gmt:batch`
     - :doc:`gmt:events`
@@ -401,7 +401,7 @@
    gmtget
    gmtinfo
    gmtlogo
-   gmtmath 
+   gmtmath
    gmtselect
    gmtset
    gmtsimplify

--- a/source/module/index.rst
+++ b/source/module/index.rst
@@ -4,7 +4,7 @@
 **GMT 主程序与脚本**
 
 .. hlist::
-    :columns: 5
+    :columns: 4
 
     - :doc:`gmt`
     - :doc:`gmt-config`
@@ -13,7 +13,7 @@
 **GMT 模块（已翻译整理）**
 
 .. hlist::
-    :columns: 5
+    :columns: 4
 
     - :doc:`basemap`
     - :doc:`begin`
@@ -142,7 +142,7 @@
 **GMT 模块（尚未翻译整理，欢迎贡献）**
 
 .. hlist::
-    :columns: 5
+    :columns: 4
 
     - :doc:`gmt:batch`
     - :doc:`gmt:events`


### PR DESCRIPTION
The current module list (https://docs.gmt-china.org/latest/module/) looks bad on mobile phones:

<img width="358" alt="image" src="https://github.com/gmt-china/GMT_docs/assets/3974108/ca4454dd-b9c3-49bd-bed1-a2009ca67df8">

This PR tries to decrease the number of columns of the module list.
