### PR TITLE
Remove the requirements.txt file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: gmt-docs
+name: gmtdocs
 channels:
   - conda-forge
   - nodefaults

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-sphinx
-sphinx-cjkspace
-sphinx-copybutton
-sphinx-design
-sphinx_rtd_theme
-sphinxcontrib.datatemplates

--- a/source/contributing.rst
+++ b/source/contributing.rst
@@ -56,7 +56,8 @@ GitHub 上托管的文档仓库中存在如下长期分支：
     ::
 
         $ cd GMT_docs
-        $ pip install -r requirements.txt
+        $ conda env create -f environment.yml
+        $ conda activate gmtdocs
 
 4.  编译生成 HTML 格式的文档
 


### PR DESCRIPTION
Use environment.yml to create a conda enviroment, instead of using requirements.txt.

This PR removes requirements.txt which is no longer used. I also update the
contributing guides to use environment.yml.

Please note that the contributing guides are still problematic, because contributors
still need to setup the dataset, custom symbols, chinese fonts et al to
successfully build the documentation locally.

We will update the contributing guides later.
