### PR TITLE
Move the migrating guides to appendix

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -50,7 +50,6 @@ GMT 是地球科学使用最广泛的制图软件之一。
 
    intro
    install/index
-   migrating/index
    tutorial/started
    tutorial/advanced
 
@@ -86,5 +85,6 @@ GMT 是地球科学使用最广泛的制图软件之一。
 
    utilities/index
    contour-annot/index
+   migrating/index
    contributing
    贡献者 <https://github.com/gmt-china/GMT_docs#%E8%B4%A1%E7%8C%AE%E8%80%85->


### PR DESCRIPTION
迁移指南对新用户而言是没用的，不应该放在正文中。