### PR TITLE
xdg-utils is required on Linux

### DIFF
--- a/source/install/build-source-unix.rst
+++ b/source/install/build-source-unix.rst
@@ -37,7 +37,7 @@ Fedora::
 
     # 安装必须软件包
     $ sudo dnf install gcc cmake make glibc netcdf-devel libcurl-devel
-    $ sudo dnf install ghostscript gdal gdal-devel geos-devel lapack-devel openblas-devel glib2-devel pcre-devel fftw-devel
+    $ sudo dnf install ghostscript xdg-utils gdal gdal-devel geos-devel lapack-devel openblas-devel glib2-devel pcre-devel fftw-devel
     # 安装可选软件包
     $ sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-`rpm -E %fedora`.noarch.rpm
     $ sudo dnf install GraphicsMagick ffmpeg
@@ -48,7 +48,7 @@ Ubuntu/Debian::
     $ sudo apt update
     # 安装必须软件包
     $ sudo apt install build-essential cmake libcurl4-gnutls-dev libnetcdf-dev
-    $ sudo apt install ghostscript gdal-bin libgdal-dev libgeos-dev libglib2.0-dev libpcre3-dev libfftw3-dev liblapack-dev
+    $ sudo apt install ghostscript xdg-utils gdal-bin libgdal-dev libgeos-dev libglib2.0-dev libpcre3-dev libfftw3-dev liblapack-dev
     # 安装可选软件包
     $ sudo apt install graphicsmagick ffmpeg
 

--- a/source/install/fedora.rst
+++ b/source/install/fedora.rst
@@ -31,7 +31,7 @@ Fedora 37、Fedora 38 和 Fedora rawhide 的官方源中提供了 GMT 6.4.0，�
 
 制作 GIF 格式的动画需要 `GraphicsMagick <http://www.graphicsmagick.org/>`__ [**可选**]::
 
-        $ sudo dnf install GraphicsMagick
+    $ sudo dnf install GraphicsMagick
 
 制作 MP4、WebM 格式的动画需要 FFmpeg [**可选**]::
 

--- a/source/install/ubuntu-debian.rst
+++ b/source/install/ubuntu-debian.rst
@@ -30,6 +30,10 @@ Ubuntu 23.04 和 Debian 12 官方源中提供了 GMT 6.4.0，可直接通过如�
 
         $ sudo apt install ghostscript
 
+    自动打开生成的图片需要 ``xdg-utils``::
+
+        $ sudo apt install xdg-utils
+
     地理空间数据格式转换工具 `GDAL <https://gdal.org/>`__ [**必须**]::
 
         $ sudo apt install gdal-bin


### PR DESCRIPTION
On Linux, GMT uses `xdg-open` to open images.