### PR TITLE
Clever gallery template

### DIFF
--- a/source/_extensions/templatebridge.py
+++ b/source/_extensions/templatebridge.py
@@ -1,14 +1,26 @@
-from sphinx.jinja2glue import BuiltinTemplateLoader
-
+"""
+Add custom filters to the Jinja2 environment.
+"""
 import hashlib
 
+from sphinx.jinja2glue import BuiltinTemplateLoader
+
+
 def _filemd5(file):
-    with open(file, 'r') as fp:
+    """
+    Return the MD5 hash of the file contents.
+    """
+    with open(file, "r") as fp:
         data = fp.read()
         return hashlib.md5(data.encode()).hexdigest()
 
+
 class MyTemplateBridge(BuiltinTemplateLoader):
+    """
+    Inherit from the default template bridge and add custom filters.
+    """
+
     def init(self, builder, template_name):
         super().init(builder, template_name)
-        self.environment.filters['filemd5'] = _filemd5
-
+        # Add custom filters
+        self.environment.filters["filemd5"] = _filemd5

--- a/source/_extensions/templatebridge.py
+++ b/source/_extensions/templatebridge.py
@@ -1,0 +1,14 @@
+from sphinx.jinja2glue import BuiltinTemplateLoader
+
+import hashlib
+
+def _filemd5(file):
+    with open(file, 'r') as fp:
+        data = fp.read()
+        return hashlib.md5(data.encode()).hexdigest()
+
+class MyTemplateBridge(BuiltinTemplateLoader):
+    def init(self, builder, template_name):
+        super().init(builder, template_name)
+        self.environment.filters['filemd5'] = _filemd5
+

--- a/source/_templates/gallery.tmpl
+++ b/source/_templates/gallery.tmpl
@@ -6,12 +6,18 @@
 
 .. grid:: 2 3 3 4
     {% for fig in group["gallery"] %}
-    {% if fig["image"].startswith("http") %}  {# absolute URL for external images #}
-        {% set image = fig["image"] %}
-        {% set link, link_type = "/" + fig["target"], "doc" %}
-    {% else %}  {# internal images #}
-        {% set image = config.html_context["siteurl"] + "/_images/" + fig["image"] + ".png" %}
-        {% set link, link_type = "gmtplot-" + fig["image"], "ref" %}
+        {% if fig["script"] is defined %}
+        {% set md5value = fig["script"] | filemd5 %}
+        {% set image = config.html_context["siteurl"] + "/_images/" + md5value + ".png" %}
+        {% set link, link_type = "gmtplot-" + md5value, "ref" %}
+    {% else %}
+        {% if fig["image"].startswith("http") %}  {# absolute URL for external images #}
+            {% set image = fig["image"] %}
+            {% set link, link_type = "/" + fig["target"], "doc" %}
+        {% else %}  {# internal images #}
+            {% set image = config.html_context["siteurl"] + "/_images/" + fig["image"] + ".png" %}
+            {% set link, link_type = "gmtplot-" + fig["image"], "ref" %}
+        {% endif %}
     {% endif %}
     .. grid-item-card::
         :margin: 0 2 0 0

--- a/source/_templates/gallery.tmpl
+++ b/source/_templates/gallery.tmpl
@@ -7,18 +7,18 @@
 .. grid:: 2 3 3 4
     {% for fig in group["gallery"] %}
         {% if fig["script"] is defined %}
-        {% set md5value = fig["script"] | filemd5 %}
-        {% set image = config.html_context["siteurl"] + "/_images/" + md5value + ".png" %}
-        {% set link, link_type = "gmtplot-" + md5value, "ref" %}
-    {% else %}
-        {% if fig["image"].startswith("http") %}  {# absolute URL for external images #}
-            {% set image = fig["image"] %}
-            {% set link, link_type = "/" + fig["target"], "doc" %}
-        {% else %}  {# internal images #}
-            {% set image = config.html_context["siteurl"] + "/_images/" + fig["image"] + ".png" %}
-            {% set link, link_type = "gmtplot-" + fig["image"], "ref" %}
-        {% endif %}
-    {% endif %}
+			{% set md5value = fig["script"] | filemd5 %}
+	        {% set image = config.html_context["siteurl"] + "/_images/" + md5value + ".png" %}
+		    {% set link, link_type = "gmtplot-" + md5value, "ref" %}
+	    {% else %}
+		    {% if fig["image"].startswith("http") %}  {# absolute URL for external images #}
+			    {% set image = fig["image"] %}
+				{% set link, link_type = "/" + fig["target"], "doc" %}
+	        {% else %}  {# internal images #}
+		        {% set image = config.html_context["siteurl"] + "/_images/" + fig["image"] + ".png" %}
+			    {% set link, link_type = "gmtplot-" + fig["image"], "ref" %}
+	        {% endif %}
+		{% endif %}
     .. grid-item-card::
         :margin: 0 2 0 0
         :text-align: center

--- a/source/_templates/gallery.tmpl
+++ b/source/_templates/gallery.tmpl
@@ -6,19 +6,19 @@
 
 .. grid:: 2 3 3 4
     {% for fig in group["gallery"] %}
-        {% if fig["script"] is defined %}
-			{% set md5value = fig["script"] | filemd5 %}
-	        {% set image = config.html_context["siteurl"] + "/_images/" + md5value + ".png" %}
-		    {% set link, link_type = "gmtplot-" + md5value, "ref" %}
-	    {% else %}
-		    {% if fig["image"].startswith("http") %}  {# absolute URL for external images #}
-			    {% set image = fig["image"] %}
-				{% set link, link_type = "/" + fig["target"], "doc" %}
-	        {% else %}  {# internal images #}
-		        {% set image = config.html_context["siteurl"] + "/_images/" + fig["image"] + ".png" %}
-			    {% set link, link_type = "gmtplot-" + fig["image"], "ref" %}
-	        {% endif %}
-		{% endif %}
+    {% if fig["script"] is defined %}
+        {% set md5value = fig["script"] | filemd5 %}
+        {% set image = config.html_context["siteurl"] + "/_images/" + md5value + ".png" %}
+        {% set link, link_type = "gmtplot-" + md5value, "ref" %}
+    {% else %}
+        {% if fig["image"].startswith("http") %}  {# absolute URL for external images #}
+            {% set image = fig["image"] %}
+            {% set link, link_type = "/" + fig["target"], "doc" %}
+        {% else %}  {# internal images #}
+            {% set image = config.html_context["siteurl"] + "/_images/" + fig["image"] + ".png" %}
+            {% set link, link_type = "gmtplot-" + fig["image"], "ref" %}
+        {% endif %}
+    {% endif %}
     .. grid-item-card::
         :margin: 0 2 0 0
         :text-align: center

--- a/source/conf.py
+++ b/source/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "gmtplot",
     "sphinxcontrib.datatemplates",
 ]
+template_bridge = "templatebridge.MyTemplateBridge"
 #mathjax_path = "https://cdn.bootcss.com/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 
 # Set smartquotes_action to "qe" to disable Smart Quotes transform of -- and ---

--- a/source/conf.py
+++ b/source/conf.py
@@ -58,7 +58,7 @@ extensions = [
     "gmtplot",
     "sphinxcontrib.datatemplates",
 ]
-# use custom templater bridge defined in _extensions/templatebridge
+# use custom templater bridge defined in _extensions/templatebridge.py
 template_bridge = "templatebridge.MyTemplateBridge"
 #mathjax_path = "https://cdn.bootcss.com/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -58,6 +58,7 @@ extensions = [
     "gmtplot",
     "sphinxcontrib.datatemplates",
 ]
+# use custom templater bridge defined in _extensions/templatebridge
 template_bridge = "templatebridge.MyTemplateBridge"
 #mathjax_path = "https://cdn.bootcss.com/mathjax/2.7.7/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 

--- a/source/gallery/gallery.yaml
+++ b/source/gallery/gallery.yaml
@@ -1,7 +1,7 @@
 ---
 title: 底图
 gallery:
-  - image: d44026c69907320e8680c507fffc6066
+  - script: conf/map_frame_type.sh
     title: MAP_FRAME_TYPE 控制底图边框类型
     target: conf/map/
   - image: d6a56a56fddb4bb54d57466b9d1e45c3


### PR DESCRIPTION
**Preview**: https://gmtchina-gmt-docs--1223.org.readthedocs.build/zh_CN/1223/gallery/index.html

---

社区的绘图实例页面(https://docs.gmt-china.org/latest/gallery/) 由配置文件 [gallery.yaml](https://github.com/gmt-china/GMT_docs/blob/main/source/gallery/gallery.yaml) 控制，每张图对应一个记录，一个记录的基本格式是:
```
  - image: d44026c69907320e8680c507fffc6066
    title: MAP_FRAME_TYPE 控制底图边框类型
    target: conf/map/
```
其中，`image` 是图片对应的 md5 hash 值，而这个 md5 hash 值是根据生成图片的脚本的内容决定的。例如，脚本 `map.sh` 生成的图片的 md5 值为 `md5sum map.sh` 的返回值。

这里存在两个问题：

1. 新手很能难以理解这个字符串怎么来的。
2. 当脚本内容发生任何一点改变时，脚本的 md5 也会变化，因而必须修改 gallery.yaml 里的相关 md5 值。但经常会忘掉（如 #1221）

这个 PR 主要是想解决这两个问题，新语法中，一个记录对应的格式为：
```
  - script: conf/map_frame_type.sh
    title: MAP_FRAME_TYPE 控制底图边框类型
    target: conf/map/
```
其中 `script` 是脚本的路径。模板会自动读取该脚本的内容，确定其 md5 值，然后得到对应的图片的文件名。

该 PR 解决了以上两个问题，但带来一个新的问题，`script` 后面必须要跟一个脚本文件名，但是手册中的某些图片是通过 `gmtplot` 的行内模式生成的，例如
```
.. gmtplot::
    :caption: 图片标题
    :width: 80%

    gmt begin map
    gmt basemap -JX10c/10c -R0/10/0/10 -Baf
    gmt end show
```
这种情况下，找不到对应的脚本文件名，所以没法包含到 gallery 中。

解决办法是，将这个行内模式的脚本改写到单独的脚本文件中，工作量稍微有点大。

