### PR TITLE
Correctly show gallery examples in PDF

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 name: Deploy
 
 on:
-  # pull_request: # enable pull_request for testing
+  pull_request: # enable pull_request for testing
   push:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@
 name: Deploy
 
 on:
-  pull_request: # enable pull_request for testing
+  # pull_request: # enable pull_request for testing
   push:
     branches:
       - main

--- a/source/gallery/index.rst
+++ b/source/gallery/index.rst
@@ -5,7 +5,7 @@
 
     .. datatemplate:yaml:: gallery.yaml
         :template: gallery.tmpl
-           :multiple-documents:
+        :multiple-documents:
 
 .. only:: latex
 

--- a/source/gallery/index.rst
+++ b/source/gallery/index.rst
@@ -1,9 +1,18 @@
 社区绘图实例
 ############
 
-.. datatemplate:yaml:: gallery.yaml
-   :template: gallery.tmpl
-   :multiple-documents:
+.. only:: html
+
+    .. datatemplate:yaml:: gallery.yaml
+        :template: gallery.tmpl
+           :multiple-documents:
+
+.. only:: latex
+
+    .. toctree::
+        :glob:
+
+        examples/ex*/index
 
 外部绘图实例
 ############

--- a/source/gallery/index.rst
+++ b/source/gallery/index.rst
@@ -12,7 +12,7 @@
     .. toctree::
         :glob:
 
-        examples/ex*/index
+        /examples/ex*/index
 
 外部绘图实例
 ############


### PR DESCRIPTION
If you look at the PDF version of the documentation, you will see many images in chapter 5:

case 1:
<img width="823" alt="image" src="https://github.com/gmt-china/GMT_docs/assets/3974108/95eca9f9-e9b8-487b-8f9b-7a711af35243">

case 2:
<img width="646" alt="image" src="https://github.com/gmt-china/GMT_docs/assets/3974108/4bf241ad-1cd8-4f7b-a24a-d5a292532263">

For images like case 1, they're already included somewhere in the documentation, so it makes no sense to include them again in the "Gallery Examples" chapter.

For images like case 2, they're real examples in the `source/examples/` directory. The images are included in the PDF but the corresponding scripts are **NOT**. So they're also useless in PDF.

This PR fixes the issue by:

1. Removing all image like case 1 in PDF
2. Include all real examples and the corresponding file for case 2 in PDF
