### PR TITLE
insert gif only in building the HTML

### DIFF
--- a/source/module/movie.rst
+++ b/source/module/movie.rst
@@ -49,11 +49,13 @@ movie
 并可选择组合成动画（这最后一步需要外部工具，这些工具必须存在于用户的路径中；
 请参阅下面的 `技术细节`_ ）。用户可以根据需要添加片头、淡入淡出效果、标签和进度指示器。
 
-:download:`Source Code <https://dengda98.github.io/zh/posts/tech/gmt_movie/movie_ex01.sh>`
+.. only:: html
 
-.. figure:: https://dengda98.github.io/zh/posts/tech/gmt_movie/anim01.gif
-    :width: 500 px
-    :align: center
+    :download:`Source Code <https://dengda98.github.io/zh/posts/tech/gmt_movie/movie_ex01.sh>`
+
+    .. figure:: https://dengda98.github.io/zh/posts/tech/gmt_movie/anim01.gif
+        :width: 500 px
+        :align: center
 
 必选选项
 --------
@@ -672,11 +674,13 @@ GMT 建议用户参考这篇有用的
 
     gmt movie globe.sh -Nglobe -T360 -Fgif -C6ix6ix100 -Lf -P
 
-:download:`Source Code <https://dengda98.github.io/zh/posts/tech/gmt_movie/movie_ex02.sh>`
+.. only:: html
 
-.. figure:: https://dengda98.github.io/zh/posts/tech/gmt_movie/globe.gif
-    :width: 500 px
-    :align: center
+    :download:`Source Code <https://dengda98.github.io/zh/posts/tech/gmt_movie/movie_ex02.sh>`
+
+    .. figure:: https://dengda98.github.io/zh/posts/tech/gmt_movie/globe.gif
+        :width: 500 px
+        :align: center
 
 在执行过程结束时，用户会发现了 GIF 文件 *globel.gif* 以及一个目录 *glob* ，
 其中包含了全部 360 张 PNG 图片。请注意， *globe.sh* 脚本中没有包含任何反映图表名称、


### PR DESCRIPTION
在 #1485 基础上，仅增加 `.. only:: html` ，即在构建pdf时跳过gif图片。
本地已测试，能成功构建pdf。