### PR TITLE
Remove the install instructions via macports on macOS

### DIFF
--- a/source/install/macOS.md
+++ b/source/install/macOS.md
@@ -8,7 +8,7 @@ date: 2025-07-28
 macOS 下安装 GMT 有多种方式：
 
 1. [使用 Homebrew 安装](macos-homebrew) [**推荐**]
-3. {doc}`conda`
+2. {doc}`conda`
 
 (macos-homebrew)=
 ## 使用 Homebrew 安装


### PR DESCRIPTION
This PR removes the installation instructions for macOS users via MacPorts. The main reason is that MacPorts has far fewer users than Homebrew, especially in China.

For reference, over the past 365 days, there were only 8 installations via MacPorts (https://ports.macports.org/port/gmt6/stats/?days=365&days_ago=0) compared to 3,144 via Homebrew (https://formulae.brew.sh/formula/gmt).
