### PR TITLE
Fix `|Add_-Rgeo|` substitution errors

### DIFF
--- a/source/module/barb.rst
+++ b/source/module/barb.rst
@@ -51,6 +51,7 @@ barb
 
 .. include:: explain_-Jz.rst_
 
+.. |Add_-Rgeo| replace:: |Add_-R_auto_table|
 .. include:: explain_-Rgeo.rst_
 
 .. include:: explain_-Rz.rst_

--- a/source/module/grdbarb.rst
+++ b/source/module/grdbarb.rst
@@ -103,7 +103,7 @@ grdbarb
     - **+s** - 设置长羽对应的风速 [默认 5]。
     - **+w** - 设置风羽的宽度。
 
-
+.. |Add_-Rgeo| replace:: |Add_-R_auto_table|
 .. include:: explain_-Rgeo.rst_
 
 .. _-T:

--- a/source/module/grdpmodeler.rst
+++ b/source/module/grdpmodeler.rst
@@ -76,6 +76,7 @@ grdpmodeler
 
 .. include:: explain_-I.rst_
 
+.. |Add_-Rgeo| unicode:: 0x20 .. 仅为占位符
 .. include:: explain_-Rgeo.rst_
 
 .. _-T:

--- a/source/module/grdrotater.rst
+++ b/source/module/grdrotater.rst
@@ -78,6 +78,7 @@ grdrotater
 **-N**
     不输出旋转后的多边形轮廓线 [默认将其写入标准输出，或通过 |-D| 写入文件]。
 
+.. |Add_-Rgeo| unicode:: 0x20 .. 仅为占位符
 .. include:: explain_-Rgeo.rst_
 
 .. _-S:

--- a/source/module/grdspotter.rst
+++ b/source/module/grdspotter.rst
@@ -50,7 +50,7 @@ grdspotter
 
 .. include:: explain_-I.rst_
 
-
+.. |Add_-Rgeo| unicode:: 0x20 .. 仅为占位符
 .. include:: explain_-Rgeo.rst_
 
 可选选项

--- a/source/module/hotspotter.rst
+++ b/source/module/hotspotter.rst
@@ -53,6 +53,7 @@ hotspotter
 
 .. include:: explain_-I.rst_
 
+.. |Add_-Rgeo| unicode:: 0x20 .. 仅为占位符
 .. include:: explain_-Rgeo.rst_
 
 可选选项

--- a/source/module/originater.rst
+++ b/source/module/originater.rst
@@ -147,8 +147,6 @@ originater
 
 .. include:: explain_help.rst_
 
-.. include:: explain_-Rgeo.rst_
-
 .. include:: explain_geodetic.rst_
 
 示例

--- a/source/module/polespotter.rst
+++ b/source/module/polespotter.rst
@@ -79,6 +79,7 @@ polespotter
 **-N**
     归一化网格，使最大值等于 1 [默认不归一化]。
 
+.. |Add_-Rgeo| unicode:: 0x20 .. 仅为占位符
 .. include:: explain_-Rgeo.rst_
 
 .. _-S:


### PR DESCRIPTION
仿照官方文档的做法，将其替换为一个隐形的占位符，不然会渲染出一个蓝色的无效引用