### PR TITLE
Update source_suffix in conf.py

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -36,7 +36,10 @@ rst_prolog = """
 
 # -- General configuration ------------------------------------------------
 needs_sphinx = "2.4"
-source_suffix = ".rst"
+source_suffix = {
+    '.rst': 'restructuredtext',  # 遇到 .rst 用默认解析器
+    '.md': 'markdown',           # 遇到 .md 用 MyST 解析器
+}
 source_encoding = "utf-8-sig"
 nitpicky = True
 language = "zh_CN"


### PR DESCRIPTION
没有副作用，保证 Sphinx 绝对能正确识别 .md 文件
明确告诉 Sphinx 哪种后缀用哪种解析器，避免歧义
