### PR TITLE
fix warnings about figures

### DIFF
--- a/source/_templates/gallery.tmpl
+++ b/source/_templates/gallery.tmpl
@@ -31,7 +31,10 @@
         :link: {{ link }}
         :link-type: {{ link_type }}
 
-        .. figure:: {{ image }}
+        .. raw:: html
+
+            <img src="{{ image }}" alt="{{ fig['title'] }}" class="figure-img" style="width: 100%; object-fit: contain;">
+
         +++
         **{{ fig["title"] }}**
     {% endfor %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -123,7 +123,9 @@ elif os.getenv("READTHEDOCS"):  # Preview PRs powered by ReadTheDocs
     siteurl_for_gallery = os.getenv("READTHEDOCS_CANONICAL_URL")
     basedir_for_gallery = "./"
 else:  # build locally
-    siteurl_for_gallery = ""
+    # 修改说明：使用 ".." 表示上一级目录，这样路径会变成 "../_images/xxx.png"
+    # 这允许在 build/html/gallery/index.html 中通过相对路径找到 build/html/_images/ 下的图片
+    siteurl_for_gallery = ".."
     basedir_for_gallery = "source/"
 
 html_context = {


### PR DESCRIPTION
解决make html中出现的两个问题：

1.警告信息：
```
/home/chenxh/Desktop/GMT/GMT_docs/gallery.yaml:1: WARNING: image file not readable: _images/7fe7f53a52f9a1682c3a3d2ffd2ce122.png
/home/chenxh/Desktop/GMT/GMT_docs/gallery.yaml:1: WARNING: image file not readable: _images/c90ae96737de94832fa4b48378e978d8.png
/home/chenxh/Desktop/GMT/GMT_docs/gallery.yaml:1: WARNING: image file not readable: _images/a5f01711e98607e75d5d4e1612692a8d.png
...
```

路径以 / 开头（例如 /_images/xxx.png）时，Sphinx 默认去源码目录 (source/_images/) 查找文件，以便计算图片大小或将其复制到构建目录。

但图片是由 gmtplot 脚本动态生成的。它们存在于 构建目录 (build/html/_images/) 中，而不是源码目录中。

Sphinx 在源码目录找不到这些图片，于是报 WARNING: image file not readable，并且拒绝在生成的 HTML 中插入这些图片的标签。

使用 原生 HTML标签 (.. raw:: html) 替代 Sphinx 的 .. figure:: 指令。

这样做的目的是告诉 Sphinx：“不要去检查这个文件是否存在，直接把 `<img src="...">` 标签写到 HTML 里就行了，浏览器到时候能找到它。”


2. 本地编译的html无法显示图片

在HTML 代码中：`<img src="/_images/xxx.png">`，以斜杠 / 开头代表绝对路径。

直接打开 HTML，浏览器认为 / 是Linux 系统根目录 /。它会去 /_images/xxx.png 找图片，而不是项目目录。

使用 Web 服务器 (http://)：浏览器认为 / 是网站的根目录。 /_images/ 能正确对应到图片

需要修改 conf.py，把路径改为相对路径。