### PR TITLE
update to PDF 2.0 (ISO 32000-2:2020)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ pdf: latex
 
 # reduce file size of the final PDF documentation
 optimize_pdf: pdf
-	gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/prepress \
+	gs -sDEVICE=pdfwrite -dCompatibilityLevel=2.0 -dPDFSETTINGS=/prepress \
 		-dNOPAUSE -dQUIET -dBATCH \
 		-sOutputFile=$(BUILDDIR)/$(DOCNAME).optimized.pdf \
 		$(BUILDDIR)/$(DOCNAME).pdf


### PR DESCRIPTION
PDF 2.0 已经是2020年发布的了。并且实测生成的pdf会小一点，1.4: 42.2 MB -> 2.0: 39.6 MB