### PR TITLE
Remove Star History Chart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,3 @@ GMT 中文手册由以下贡献者维护：
 | 💡 | example | 增添示例 | 🤔 | ideas | 建议与想法 |
 | 🚧 | maintenance | 底层维护 | 👀 | review | 审核文档 |
 | 📹 | video | 录制视频教程 | | ||
-
-[![Star History Chart](https://api.star-history.com/svg?repos=gmt-china/GMT_docs&type=Date)](https://star-history.com/#gmt-china/GMT_docs&Date)


### PR DESCRIPTION
As reported in https://github.com/GenericMappingTools/pygmt-paper-figures/pull/76, star history no longer works.

Related reference:

- https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/
- https://www.star-history.com/blog/github-stargazer-api-restriction/